### PR TITLE
Remove icon lookup with the filename for directories

### DIFF
--- a/src/Haskellorls/LsColor/Icon.hs
+++ b/src/Haskellorls/LsColor/Icon.hs
@@ -71,7 +71,7 @@ instance Dictionary NodeInfo Icon LsIcons where
       BlockDevise -> block
       CharDevise -> char
       Orphan -> orphan
-      Directory -> Query filename `query` l <|> directory
+      Directory -> directory
       _ -> Query filename `query` l <|> file
       where
         filename = T.pack . Posix.takeFileName $ getNodePath n


### PR DESCRIPTION
This is for consistency between the `--color` option and the `--icons` option, the `--color` option doesn't lookup escape sequence parameter with the filename for directories. This behavior stems from GNU ls.