### PR TITLE
Remove the 'executable-static' config

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,3 @@
 packages: ./
 
-executable-static: true
-
 index-state: 2022-02-25T19:35:02Z


### PR DESCRIPTION
This causes a link error on 'cabal build'.