### PR TITLE
Remove hie.yaml

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,7 +1,0 @@
-cradle:
-  cabal:
-    - path: "src"
-      component: "lib:haskellorls"
-
-    - path: "app/Main.hs"
-      component: "haskellorls:exe:haskellorls"


### PR DESCRIPTION
The reason is that this project is very simple and is probably no need to specify the project structure explicitly.