### PR TITLE
Remove a redundant build-type filed

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,3 +1,0 @@
-import Distribution.Simple
-
-main = defaultMain

--- a/haskellorls.cabal
+++ b/haskellorls.cabal
@@ -6,7 +6,6 @@ license:            BSD-3-Clause
 license-file:       LICENSE
 maintainer:         12132068+a5ob7r@users.noreply.github.com
 author:             a5ob7r
-build-type:         Simple
 tested-with:
   GHC ==8.6.5 || ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.3
 


### PR DESCRIPTION
If 'cabal-version' is 2.2 or higher, the default value of it is 'Simple', and Cabal assumes the content of 'Setup.hs' automatically. So
no need to specify it explicitly.

https://cabal.readthedocs.io/en/3.6/cabal-package.html#pkg-field-build-type