### PR TITLE
Fix quotation compatibilities with GNU ls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,16 @@
 - Improve compatibility with GNU ls about formatting file size and block size.
 - The default column size is 80.
 - Show major numbers and minor numbers for block devices and character devices instead of each file size.
+- `--show-control-chars` and `-q / --hide-control-chars` are exclusive.
+- By default quoting-style is `shell-escape` if the stdout is connected to a terminal, otherwise `literal`.
+- By default implies `-q / --hide-control-chars` if the stdout is connected to a terminal, otherwise `--show-control-chars`.
 
 ### Fixed
 
 - Remove a trailing space of each line for `-m`.
 - Doesn't ignore any punctuation when sorts using flename.
 - Return no error status even if errors occur in directory traversing with `--tree`.
+- Quotation for `" |` by `--name-quote` and `--escape`.
 
 ## 0.5.3.0 -- 2022-07-23
 

--- a/golden-test/LiteralOneArgumentWhichHaveNeedQuoteContentsNoEnv.goldplate
+++ b/golden-test/LiteralOneArgumentWhichHaveNeedQuoteContentsNoEnv.goldplate
@@ -1,6 +1,6 @@
 {
   "command": "haskellorls",
-  "arguments": ["--literal", "files/examples05"],
+  "arguments": ["--literal", "--hide-control-chars", "files/examples05"],
   "environment": {"LS_COLORS": ""},
   "asserts": [
     {"exit_code": 0},

--- a/golden-test/Width80EscapeOneArgumentNoEnv.goldplate
+++ b/golden-test/Width80EscapeOneArgumentNoEnv.goldplate
@@ -1,6 +1,6 @@
 {
   "command": "haskellorls",
-  "arguments": ["-C", "--quoting-style=shell-escape", "--width=80", "files/examples05"],
+  "arguments": ["-C", "--width=80", "--escape", "files/examples01"],
   "environment": {"LS_COLORS": ""},
   "asserts": [
     {"exit_code": 0},

--- a/golden-test/Width80EscapeOneArgumentNoEnv.stdout
+++ b/golden-test/Width80EscapeOneArgumentNoEnv.stdout
@@ -1,0 +1,3 @@
+haskell-README.md     haskell.README.md.en  readme.md.en       README.rst
+haskell.readme.md     readme                README.md-haskell
+haskell-README.md.en  README.md             README.md.haskell

--- a/golden-test/Width80EscapeOneArgumentWhichHaveNeedQuoteContentsNoEnv.goldplate
+++ b/golden-test/Width80EscapeOneArgumentWhichHaveNeedQuoteContentsNoEnv.goldplate
@@ -1,6 +1,6 @@
 {
   "command": "haskellorls",
-  "arguments": ["-C", "--quoting-style=shell-escape", "--width=80", "files/examples05"],
+  "arguments": ["-C", "--width=80", "--escape", "files/examples05"],
   "environment": {"LS_COLORS": ""},
   "asserts": [
     {"exit_code": 0},

--- a/golden-test/Width80EscapeOneArgumentWhichHaveNeedQuoteContentsNoEnv.stdout
+++ b/golden-test/Width80EscapeOneArgumentWhichHaveNeedQuoteContentsNoEnv.stdout
@@ -1,0 +1,3 @@
+double_quote01"".txt  file02.txt            space01\ .txt
+double_quote02"".txt  single_quote01'.txt   space02\ \ .txt
+file01.txt            single_quote02''.txt  tab\t.txt

--- a/golden-test/Width80OneArgumentWhichHaveNeedQuoteContentsNoEnv.stdout
+++ b/golden-test/Width80OneArgumentWhichHaveNeedQuoteContentsNoEnv.stdout
@@ -1,3 +1,3 @@
 'double_quote01"".txt'   file02.txt             'space01 .txt'
 'double_quote02"".txt'  "single_quote01'.txt"   'space02  .txt'
- file01.txt             "single_quote02''.txt"   tab	.txt
+ file01.txt             "single_quote02''.txt"  "tab'$'\t''.txt"

--- a/golden-test/Width80QuoteNameOneArgumentWhichHaveNeedQuoteContentsNoEnv.stdout
+++ b/golden-test/Width80QuoteNameOneArgumentWhichHaveNeedQuoteContentsNoEnv.stdout
@@ -1,3 +1,3 @@
 "double_quote01\"\".txt"  "file02.txt"            "space01 .txt"
 "double_quote02\"\".txt"  "single_quote01'.txt"   "space02  .txt"
-"file01.txt"              "single_quote02''.txt"  "tab	.txt"
+"file01.txt"              "single_quote02''.txt"  "tab\t.txt"

--- a/src/Haskellorls/Config/Option.hs
+++ b/src/Haskellorls/Config/Option.hs
@@ -59,10 +59,9 @@ data Option = Option
     oLiteral :: Bool,
     oLongWithoutGroup :: Bool,
     oDirectoryIndicator :: Bool,
-    oHideControlChars :: Bool,
-    oShowControlChars :: Bool,
+    oShowControlChars :: Maybe Bool,
     oQuoteName :: Bool,
-    oQuotingStyle :: Quote.QuotingStyle,
+    oQuotingStyle :: Maybe Quote.QuotingStyle,
     oReverse :: Bool,
     oRecursive :: Bool,
     oSize :: Bool,
@@ -132,7 +131,6 @@ optionParser =
     <*> literalParser
     <*> longWithoutGroupParser
     <*> directoryIndicatorParser
-    <*> hideControlCharsParser
     <*> showControlCharsParser
     <*> quoteNameParser
     <*> Quote.quotingStyleParser
@@ -448,18 +446,18 @@ literalParser =
       <> short 'N'
       <> help "Output file name and link name without quoting; and replace all non printable characters to '?'"
 
-hideControlCharsParser :: Parser Bool
-hideControlCharsParser =
-  switch $
-    long "hide-control-chars"
-      <> short 'q'
-      <> help "Output '?' instead of control characters"
-
-showControlCharsParser :: Parser Bool
-showControlCharsParser =
-  switch $
-    long "show-control-chars"
-      <> help "Output control characters 'as is'"
+showControlCharsParser :: Parser (Maybe Bool)
+showControlCharsParser = sParser <|> hParser
+  where
+    sParser =
+      flag' (Just True) $
+        long "show-control-chars"
+          <> help "Output control characters 'as is'"
+    hParser =
+      flag Nothing (Just False) $
+        long "hide-control-chars"
+          <> short 'q'
+          <> help "Output '?' instead of control characters"
 
 kibibytesParser :: Parser Bool
 kibibytesParser =

--- a/src/Haskellorls/Config/Option/Quote.hs
+++ b/src/Haskellorls/Config/Option/Quote.hs
@@ -9,18 +9,18 @@ import qualified Data.Text as T
 import Haskellorls.Config.Quote
 import Options.Applicative
 
-quotingStyleParser :: Parser QuotingStyle
+quotingStyleParser :: Parser (Maybe QuotingStyle)
 quotingStyleParser =
   option reader $
     long "quoting-style"
       <> metavar "WORD"
-      <> value NoStyle
+      <> value Nothing
       <> help "Specify file name and link name quoting style; this also effects to file name and link name escape style"
       <> completeWith ["literal", "shell", "shell-always", "shell-escape", "shell-escape-always", "c", "escape"]
   where
     reader =
       str >>= \t -> case parseQuotingStyle t of
-        Just s -> pure s
+        Just s -> return $ Just s
         Nothing -> readerError ""
 
 parseQuotingStyle :: T.Text -> Maybe QuotingStyle

--- a/src/Haskellorls/Config/Quote.hs
+++ b/src/Haskellorls/Config/Quote.hs
@@ -14,8 +14,6 @@ data QuoteStyle
 
 -- | For option parsing.
 --
--- 'NoStyle':
---   no specified
 -- 'Literal':
 --   same to @--literal@
 -- 'Shell':
@@ -33,8 +31,7 @@ data QuoteStyle
 --
 -- WIP: Add 'Locale' for @locale@
 data QuotingStyle
-  = NoStyle
-  | Literal
+  = Literal
   | Shell
   | ShellAlways
   | ShellEscape

--- a/src/Haskellorls/Formatter/Name.hs
+++ b/src/Haskellorls/Formatter/Name.hs
@@ -19,20 +19,22 @@ import qualified Haskellorls.LsColor as Color
 import qualified Haskellorls.NodeInfo as Node
 import System.FilePath.Posix.ByteString
 
+-- FIXME: Quote with double quotes even if doesn't contain any double quote.
 colorizedNodeNameWrapper :: Config.Config -> Color.LsColors -> Node.NodeInfo -> [Attr.Attribute WT.WrappedText]
 colorizedNodeNameWrapper config lc nd = Quote.quote (Quote.quoteStyle config) $ colorizedNodeName config lc nd
 
 colorizedNodeName :: Config.Config -> Color.LsColors -> Node.NodeInfo -> Attr.Attribute WT.WrappedText
 colorizedNodeName config c@(Color.Options {..}) nd = Attr.Name $ WT.WrappedText (left' <> l <> right' <> wtPrefix) wtWord (wtSuffix <> left' <> r <> right')
   where
-    WT.WrappedText {..} = Attr.unwrap $ WT.modify (Escape.escapeFormatter config) <$> nodeName config nd
+    WT.WrappedText {..} = Attr.unwrap $ WT.modify (Escape.escape config) <$> nodeName config nd
     left' = Color.unSequence $ fromMaybe "" left
     right' = Color.unSequence $ fromMaybe "" right
     l = maybe "" Color.unSequence $ nd `Color.lookup` c
     r = Color.unSequence $ fromMaybe "" reset
 
+-- FIXME: Quote with double quotes even if doesn't contain any double quote.
 nodeNameWrapper :: Config.Config -> Node.NodeInfo -> [Attr.Attribute WT.WrappedText]
-nodeNameWrapper config node = Quote.quote (Quote.quoteStyle config) $ WT.modify (Escape.escapeFormatter config) <$> nodeName config node
+nodeNameWrapper config node = Quote.quote (Quote.quoteStyle config) $ WT.modify (Escape.escape config) <$> nodeName config node
 
 nodeName :: Config.Config -> Node.NodeInfo -> Attr.Attribute WT.WrappedText
 nodeName config@(Config.Config {hyperlink, hostname}) node =

--- a/src/Haskellorls/Formatter/Quote.hs
+++ b/src/Haskellorls/Formatter/Quote.hs
@@ -51,17 +51,14 @@ quote style wt = case style of
 -- architecture.
 quoteStyle :: Config.Config -> QuoteStyle
 quoteStyle config = case Config.quotingStyle config of
-  _ | Config.quoteName config -> DoubleQuote
-  Literal -> NoQuote
-  Shell -> DynamicQuote
-  ShellAlways -> SingleQuote
-  ShellEscape -> DynamicQuote
-  ShellEscapeAlways -> SingleQuote
   C -> DoubleQuote
   Escape -> NoQuote
-  _
-    | Config.noQuote config -> NoQuote
-    | otherwise -> DynamicQuote
+  Literal -> NoQuote
+  ShellAlways -> SingleQuote
+  ShellEscapeAlways -> SingleQuote
+  _ | Config.noQuote config -> NoQuote
+  Shell -> DynamicQuote
+  ShellEscape -> DynamicQuote
 
 quoteStyleForLink :: Config.Config -> QuoteStyle
 quoteStyleForLink config = case style of

--- a/src/Haskellorls/Formatter/SymbolicLink.hs
+++ b/src/Haskellorls/Formatter/SymbolicLink.hs
@@ -17,7 +17,7 @@ import qualified Haskellorls.NodeInfo as Node
 linkName :: Config.Config -> Node.NodeInfo -> [Attr.Attribute WT.WrappedText]
 linkName config node = case Node.getNodeLinkInfo node of
   Nothing -> []
-  _ -> prefix' : Quote.quote style (WT.modify (Escape.escapeFormatter config) <$> link)
+  _ -> prefix' : Quote.quote style (WT.modify (Escape.escape config) <$> link)
   where
     style = Quote.quoteStyleForLink config
     link = Name.nodeName config $ Node.toFileInfo node

--- a/src/Haskellorls/Walk/Recursive.hs
+++ b/src/Haskellorls/Walk/Recursive.hs
@@ -96,7 +96,6 @@ run conf st = runLs conf st go
             liftIO . T.putStrLn $
               "//DIRED-OPTIONS// --quoting-style="
                 <> case Config.quotingStyle c of
-                  Quote.NoStyle -> "shell-escape"
                   Quote.Literal -> "literal"
                   Quote.Shell -> "shell"
                   Quote.ShellAlways -> "shell-always"


### PR DESCRIPTION
This is for `literal`, `c` and `escape`.