### PR TITLE
Fix unnecessary alignment with `-m / --format=commas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Return no error status even if errors occur in directory traversing with `--tree`.
 - Quotation for `" |` by `--name-quote` and `--escape`.
 - Double quotation by `--quoting-style=shell-escape` and `--quoting-style=shell-escape-always` even if a filename contains no duoble quote.
+- Align columns even if `-m / --format=commas` is enabled.
 
 ## 0.5.3.0 -- 2022-07-23
 

--- a/src/Haskellorls/Config.hs
+++ b/src/Haskellorls/Config.hs
@@ -44,6 +44,8 @@ data Config = Config
     blockSize :: Size.BlockSize,
     ignoreBackups :: Bool,
     directory :: Bool,
+    -- | When this value is 'COMMAS', every column alignment in format is
+    -- disabled.
     format :: Format.Format,
     groupDirectoriesFirst :: Bool,
     si :: Bool,


### PR DESCRIPTION
This is for compatibilities with GNU ls.