### PR TITLE
Remove unnecessary path additions for cabal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
         run: |
           mkdir -p ~/bin
           echo ~/bin >> "$GITHUB_PATH"
-          echo ~/.cabal/bin >> "$GITHUB_PATH"
 
       - name: Install goldplate
         run: |
@@ -97,9 +96,6 @@ jobs:
           key: format-${{ runner.os }}-${{ matrix.cabal }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project') }}
           restore-keys: |
             format-${{ runner.os }}-${{ matrix.cabal }}-${{ matrix.ghc }}-
-
-      - name: Add path
-        run: echo ~/.cabal/bin >> "$GITHUB_PATH"
 
       - name: Install cabal-fmt
         run: cabal install --overwrite-policy=always -j cabal-fmt


### PR DESCRIPTION
"haskell/actions/setup" automatically adds "~/.caba./bin" to PATH since
v2.3.1.
