### PR TITLE
bump optparse applicative to v0.17.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,4 +2,10 @@ packages:
   ./
   ./localeconv
 
-index-state: 2023-04-19T21:29:05Z
+index-state: 2023-05-25T12:00:16Z
+
+-- FIXME: A workaround to fix blocking output by ansi-wl-pprint (probably).
+-- Remove this if switch to optparse-applicative v0.18.0.0 because it no longer
+-- uses it.
+constraints:
+  ansi-wl-pprint == 0.6.9

--- a/haskellorls.cabal
+++ b/haskellorls.cabal
@@ -125,7 +125,7 @@ library haskellorls-internal
     , microlens-th          ^>=0.4.3.10
     , mtl                   ^>=2.3.1
     , natural-sort          ^>=0.1.2
-    , optparse-applicative  ^>=0.17.0
+    , optparse-applicative  ^>=0.17.1
     , safe-exceptions       ^>=0.1.7
     , setlocale             ^>=1.0.0.10
     , template-haskell

--- a/src/Haskellorls.hs
+++ b/src/Haskellorls.hs
@@ -1,7 +1,7 @@
 module Haskellorls (haskellorls) where
 
+import Control.Exception.Safe (catch)
 import Data.Default.Class (Default (..))
-import Data.Version (showVersion)
 import Haskellorls.Config
 import Haskellorls.Config.Environment
 import Haskellorls.Config.Option qualified as Option
@@ -10,7 +10,6 @@ import Haskellorls.System.Locale qualified as Locale
 import Haskellorls.System.OsPath.Posix.Extra (encode)
 import Haskellorls.Walk qualified as Walk
 import Options.Applicative
-import Paths_haskellorls (version)
 import System.Exit
 
 -- | Run @ls@.
@@ -26,13 +25,7 @@ haskellorls :: [String] -> IO ExitCode
 haskellorls args = do
   Locale.initialize
 
-  options <- argParser args
-
-  if Option.oVersion options
-    then do
-      putStrLn $ showVersion version
-      return ExitSuccess
-    else run options
+  (argParser args >>= run) `catch` return
 
 run :: Option.Option -> IO ExitCode
 run opt = do

--- a/src/Haskellorls/Config/Option.hs
+++ b/src/Haskellorls/Config/Option.hs
@@ -4,6 +4,7 @@ module Haskellorls.Config.Option
   )
 where
 
+import Data.Version (showVersion)
 import Haskellorls.Config.Format (Format)
 import Haskellorls.Config.Indicator (IndicatorStyle (..))
 import Haskellorls.Config.Quote (QuotingStyle)
@@ -15,6 +16,7 @@ import Haskellorls.Config.When qualified as W
 import Haskellorls.Data.Infinitable (Infinitable (..))
 import Options.Applicative hiding (header)
 import Options.Applicative.Help.Pretty
+import Paths_haskellorls (version)
 import Text.Read (readMaybe)
 import Witch (TryFromException (..), tryFrom)
 
@@ -82,13 +84,13 @@ data Option = Option
     oContext :: Bool,
     oZero :: Bool,
     oOneline :: Bool,
-    oVersion :: Bool,
     oTargets :: [FilePath]
   }
 
 opts :: ParserInfo Option
-opts = info (optionParser <**> helper) $ fullDesc <> (headerDoc . Just . pretty) header
+opts = info parser $ fullDesc <> (headerDoc . Just . pretty) header
   where
+    parser = optionParser <**> simpleVersioner (showVersion version) <**> helper
     header =
       unlines
         [ " _   _           _        _ _            _     ",
@@ -393,9 +395,6 @@ optionParser =
     <*> switch do
       short '1'
         <> help "Enable oneline layout which outputs one file by one line"
-    <*> switch do
-      long "version"
-        <> help "Show version info"
     <*> do
       many . strArgument $
         metavar "[FILE]..."

--- a/src/Haskellorls/Config/Option.hs
+++ b/src/Haskellorls/Config/Option.hs
@@ -87,7 +87,7 @@ data Option = Option
   }
 
 opts :: ParserInfo Option
-opts = info (optionParser <**> helper) $ fullDesc <> (headerDoc . Just . text) header
+opts = info (optionParser <**> helper) $ fullDesc <> (headerDoc . Just . pretty) header
   where
     header =
       unlines


### PR DESCRIPTION
- Bump optparse-applicative to v0.17.1
- Use a ready-made parser for `--version`
