### PR TITLE
add ghc98 as supported ghc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest
         ghc:
+          - '9.8.1'
           - '9.6.3'
           - '9.4.7'
           - '9.2.8'

--- a/cabal.project
+++ b/cabal.project
@@ -2,4 +2,4 @@ packages:
   ./
   ./localeconv
 
-index-state: 2023-11-25T10:53:53Z
+index-state: 2024-02-17T12:14:05Z

--- a/haskellorls.cabal
+++ b/haskellorls.cabal
@@ -6,7 +6,7 @@ license:            BSD-3-Clause
 license-file:       LICENSE
 maintainer:         12132068+a5ob7r@users.noreply.github.com
 author:             a5ob7r
-tested-with:        GHC ==9.2.8 || ==9.4.7 || ==9.6.3
+tested-with:        GHC ==9.2.8 || ==9.4.7 || ==9.6.3 || ==9.8.1
 extra-source-files:
   CHANGELOG.md
   README.md
@@ -27,7 +27,7 @@ flag selinux
   manual:      True
 
 common common-options
-  build-depends:    base >=4.14 && <4.19
+  build-depends:    base >=4.14 && <4.20
   default-language: GHC2021
   ghc-options:
     -W -Wall -Wcompat -Wredundant-constraints -Wpartial-fields

--- a/src/Haskellorls/Config/Size.hs
+++ b/src/Haskellorls/Config/Size.hs
@@ -118,8 +118,8 @@ instance TryFrom String (BlockSizeMod BlockSize) where
           _ -> Just . BlockSize $ n
         _
           | null s -> Nothing
-          | s `elem` tail (inits "human-readable") -> Just HumanReadableBI
-          | s `elem` tail (inits "si") -> Just HumanReadableSI
+          | s `elem` drop 1 (inits "human-readable") -> Just HumanReadableBI
+          | s `elem` drop 1 (inits "si") -> Just HumanReadableSI
           | otherwise -> case s of
               c : "B" -> case toUpper c of
                 'K' -> Just KiloSi

--- a/test/Test/Haskellorls/Config/Option/SizeSpec.hs
+++ b/test/Test/Haskellorls/Config/Option/SizeSpec.hs
@@ -265,7 +265,7 @@ spec = do
         _ -> False
 
     it "returns HumanReadableBI if the value is the prefix of \"human-readable\"." $ do
-      property . forAll (elements . tail $ inits "human-readable") $ \s ->
+      property . forAll (elements . drop 1 $ inits "human-readable") $ \s ->
         tryFrom s `shouldSatisfy` \case
           Right (NoMod HumanReadableBI) -> True
           _ -> False
@@ -292,7 +292,7 @@ spec = do
         _ -> True
 
     it "returns HumanReadableSI if the value is the prefix of \"si\"." $ do
-      property . forAll (elements . tail $ inits "si") $ \s ->
+      property . forAll (elements . drop 1 $ inits "si") $ \s ->
         tryFrom s `shouldSatisfy` \case
           Right (NoMod HumanReadableSI) -> True
           _ -> False


### PR DESCRIPTION
- Add GHC 9.8.1 to supported GHCs
- Replace `tail` by `drop 1` to suppress a deprecation warning
- Update index-state
